### PR TITLE
Make a few implicit dependencies explicit, to make sure the benchmarks work under CHICKEN 5.

### DIFF
--- a/compare.scm
+++ b/compare.scm
@@ -3,7 +3,7 @@
 exec csi -s $0 "$@"
 |#
 
-(use posix srfi-13 srfi-1)
+(use data-structures posix srfi-13 srfi-1)
 
 (define progs/pad 20)
 (define results/pad 10)

--- a/progs/knucleotide.scm
+++ b/progs/knucleotide.scm
@@ -5,7 +5,7 @@
 
 ;;; Adapted from chibi to CHICKEN --mario
 
-(use extras srfi-69)
+(use data-structures extras srfi-69)
 
 (define (string-copy! dst dstart src start end)
   (do ((i dstart (+ i 1))

--- a/progs/slatex.scm
+++ b/progs/slatex.scm
@@ -1,3 +1,5 @@
+(use posix)
+
 (define slatex-iters       20)
 
 (define (fatal-error . args)

--- a/run.scm
+++ b/run.scm
@@ -3,7 +3,7 @@
 exec csi -s $0 "$@"
 |#
 
-(use posix utils srfi-1 irregex)
+(use posix extras utils files data-structures srfi-1 srfi-13 irregex)
 (use (only setup-api program-path))
 
 ;;; Configurable parameters
@@ -22,7 +22,7 @@ exec csi -s $0 "$@"
   (map string->symbol
        (sort (map pathname-file
                   (glob (make-pathname (programs-dir) "*.scm")))
-             string<)))
+             string<?)))
 
 
 (define (csc)


### PR DESCRIPTION
They should still work in CHICKEN 4.  Eventually the module names will diverge, so we'll need a cond-expand, but this is probably best.

PS: The dependency on srfi-1 and srfi-13 (which are now eggs) in run.scm could probably be taken out, but I didn't feel up to it.

Als, knucleotide requires srfi-69, which is also an egg.  Perhaps it could be converted to use alists, but I don't know if that would make it a lot slower.
