### PR TITLE
Replace installation prefix detection in chicken-5; use chicken-home …

### DIFF
--- a/run.scm
+++ b/run.scm
@@ -15,6 +15,7 @@ exec csi -s $0 "$@"
      (use data-structures extras files posix utils srfi-1 srfi-13 irregex
           (only setup-api program-path))
 
+     (define installation-prefix (make-parameter (pathname-directory (program-path))))
      (define (read-full-string p) (read-all p))
      (define set-environment-variable! setenv)))
 
@@ -24,13 +25,13 @@ exec csi -s $0 "$@"
                   (chicken pathname) (chicken io) (chicken irregex)
                   (only srfi-1 make-list last remove any iota)
                   (only srfi-13 string-trim-both string-pad-right)
-                  (only setup-api program-path))
+                  (only (chicken pathname) chicken-home))
 
+          (define installation-prefix (make-parameter (pathname-directory (pathname-directory (chicken-home)))))
           (define (read-full-string p) (read-string #f p)) )))
 
 ;;; Configurable parameters
 (define repetitions (make-parameter 10))
-(define installation-prefix (make-parameter (pathname-directory (program-path))))
 (define csc-options (make-parameter ""))
 (define runtime-options (make-parameter ""))
 (define log-file (make-parameter "benchmark.log"))


### PR DESCRIPTION
…from chicken.pathname instead of program-path from setup-api